### PR TITLE
Make sure to clean cache before podspec validation

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -8,6 +8,7 @@ VERSION=$(cat version.json | jq -r .version)
 GIT_TAG=v$VERSION
 git tag -a -m "tagging $GIT_TAG" $GIT_TAG
 git push -u origin $GIT_TAG
+pod cache clean --all # will clean all pods
 pod spec lint quantumgraph.podspec
 pod trunk push quantumgraph.podspec --allow-warnings
 pod spec lint Appier.podspec


### PR DESCRIPTION
Before this commit, we found out pod may refer to older commit files to do spec validation. So we clean cache prior to validation step.